### PR TITLE
Remove unused skill bubble class

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,13 +15,6 @@
         @apply absolute inset-0 left-10 h-4 w-4 transform rotate-45 bg-white dark:bg-gray-800 md:left-14;
     }
 
-    .skill-bubble {
-        @apply inline-block px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2 rounded-full shadow-sm transition-all duration-300 ease-in-out;
-    }
-
-    .skill-bubble:hover {
-        @apply transform scale-110 shadow-md;
-    }
 }
 
 /* Custom scrollbar */


### PR DESCRIPTION
## Summary
- remove `.skill-bubble` from global CSS

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_683fa5ac6ca08323a9b68e114ddab367