### PR TITLE
Add Jest testing setup

### DIFF
--- a/__tests__/ContactForm.test.tsx
+++ b/__tests__/ContactForm.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ContactForm from '@/components/ContactForm';
+import emailjs from '@emailjs/browser';
+
+jest.mock('@emailjs/browser');
+
+const mockedSend = emailjs.send as jest.MockedFunction<typeof emailjs.send>;
+
+describe('ContactForm', () => {
+  beforeEach(() => {
+    mockedSend.mockReset();
+  });
+
+  it('shows validation error when fields are missing', async () => {
+    render(<ContactForm />);
+    const submit = screen.getByRole('button', { name: /send/i });
+
+    await userEvent.click(submit);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Please fill out all fields.');
+  });
+
+  it('shows success message when email is sent', async () => {
+    mockedSend.mockResolvedValue({ text: 'OK' } as any);
+    render(<ContactForm />);
+
+    await userEvent.type(screen.getByPlaceholderText('Your Name'), 'John');
+    await userEvent.type(screen.getByPlaceholderText('Your Email'), 'john@example.com');
+    await userEvent.type(screen.getByPlaceholderText('Your Message'), 'Hi');
+
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Your email has been sent successfully!');
+    expect(mockedSend).toHaveBeenCalled();
+  });
+});

--- a/__tests__/DarkModeToggle.test.tsx
+++ b/__tests__/DarkModeToggle.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DarkModeToggle from '@/components/DarkModeToggle';
+
+describe('DarkModeToggle', () => {
+  it('toggles dark class on html element', async () => {
+    render(<DarkModeToggle />);
+    const button = screen.getByRole('button');
+
+    // initially should not have dark class
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+    await userEvent.click(button);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    await userEvent.click(button);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,15 @@
+import '@testing-library/jest-dom/extend-expect';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    dispatchEvent: jest.fn(),
+  }),
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
@@ -34,6 +35,12 @@
     "eslint-config-next": "14.2.20",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.4",
+    "ts-jest": "^29.1.2",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.3",
+    "@testing-library/user-event": "^14.4.3"
   }
 }


### PR DESCRIPTION
## Summary
- install Jest and React Testing Library dependencies
- configure Jest with jsdom environment
- add basic tests for DarkModeToggle and ContactForm
- expose `npm test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683fa5ad405c8323a283aa205ae35b66