### PR TITLE
Improve dark mode initialization

### DIFF
--- a/__tests__/DarkModeToggle.test.tsx
+++ b/__tests__/DarkModeToggle.test.tsx
@@ -1,8 +1,21 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DarkModeToggle from '@/components/DarkModeToggle';
 
 describe('DarkModeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('uses saved theme on initial render', async () => {
+    localStorage.setItem('theme', 'dark');
+    render(<DarkModeToggle />);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+  });
+
   it('toggles dark class on html element', async () => {
     render(<DarkModeToggle />);
     const button = screen.getByRole('button');

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,22 +15,37 @@ export const metadata = {
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const themeScript = `
+    (function() {
+      const savedTheme = localStorage.getItem('theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
+    })();
+  `;
+
   return (
-    <html lang="ko" className={`${notoSansKr.className} dark`}>
-    <body className="bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100 transition-colors duration-300 relative overflow-x-hidden">
-    <Header/>
-    <main className="pt-16 min-h-screen">
-      {children}
-    </main>
-    <DarkModeToggle />
-    <footer className="bg-white dark:bg-gray-800 shadow-inner">
-      <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-        <p className="text-center text-gray-500 dark:text-gray-400">
-          © {new Date().getFullYear()} My Portfolio. All rights reserved.
-        </p>
-      </div>
-    </footer>
-    </body>
+    <html lang="ko" className={notoSansKr.className} suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+      </head>
+      <body className="bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100 transition-colors duration-300 relative overflow-x-hidden">
+        <Header/>
+        <main className="pt-16 min-h-screen">
+          {children}
+        </main>
+        <DarkModeToggle />
+        <footer className="bg-white dark:bg-gray-800 shadow-inner">
+          <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+            <p className="text-center text-gray-500 dark:text-gray-400">
+              © {new Date().getFullYear()} My Portfolio. All rights reserved.
+            </p>
+          </div>
+        </footer>
+      </body>
     </html>
   )
 }

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -4,16 +4,20 @@ import { useEffect, useState } from 'react';
 import { Moon, Sun } from 'lucide-react';
 
 export default function DarkModeToggle() {
-  const [theme, setTheme] = useState<'light' | 'dark'>('light');
-
-  useEffect(() => {
-    const savedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null;
-    if (savedTheme) {
-      setTheme(savedTheme);
-    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      setTheme('dark');
+  const getInitialTheme = (): 'light' | 'dark' => {
+    if (typeof window !== 'undefined') {
+      const savedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null;
+      if (savedTheme) {
+        return savedTheme;
+      }
+      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        return 'dark';
+      }
     }
-  }, []);
+    return 'light';
+  };
+
+  const [theme, setTheme] = useState<'light' | 'dark'>(getInitialTheme);
 
   useEffect(() => {
     if (theme === 'dark') {


### PR DESCRIPTION
## Summary
- compute the initial theme before rendering in `DarkModeToggle`
- use a script in `RootLayout` to set the dark class during first paint
- test loading theme from localStorage

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_b_683fa9e221cc8323a63756450b2b084e