### PR TITLE
Add header and page tests

### DIFF
--- a/__tests__/Header.test.tsx
+++ b/__tests__/Header.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Header from '@/components/Header';
+
+jest.mock('@/components/CustomCursor', () => () => <div data-testid="cursor" />);
+
+describe('Header mobile menu', () => {
+  it('toggles menu open and close via button', async () => {
+    render(<Header />);
+    const button = screen.getByRole('button');
+
+    // initially only desktop links should be present
+    expect(screen.getAllByText(/about/i)).toHaveLength(1);
+
+    await userEvent.click(button);
+    expect(screen.getAllByText(/about/i)).toHaveLength(2);
+
+    await userEvent.click(button);
+    expect(screen.getAllByText(/about/i)).toHaveLength(1);
+  });
+
+  it('closes menu when a mobile link is clicked', async () => {
+    render(<Header />);
+    const button = screen.getByRole('button');
+    await userEvent.click(button);
+
+    const links = screen.getAllByText(/about/i);
+    expect(links).toHaveLength(2);
+
+    await userEvent.click(links[1]);
+    expect(screen.getAllByText(/about/i)).toHaveLength(1);
+  });
+});

--- a/__tests__/Page.test.tsx
+++ b/__tests__/Page.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import Page from '@/app/page';
+
+// Mock heavy libraries that rely on browser APIs
+jest.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }: any) => <canvas data-testid="canvas">{children}</canvas>,
+  useFrame: () => {},
+}));
+
+jest.mock('@react-three/drei', () => ({
+  OrbitControls: () => null,
+}));
+
+jest.mock('react-scroll-parallax', () => ({
+  ParallaxProvider: ({ children }: any) => <div>{children}</div>,
+  Parallax: ({ children }: any) => <div>{children}</div>,
+}));
+
+// Provide IntersectionObserver
+beforeAll(() => {
+  class MockObserver {
+    observe = jest.fn();
+    disconnect = jest.fn();
+    unobserve = jest.fn();
+  }
+  (window as any).IntersectionObserver = MockObserver as any;
+});
+
+describe('Main page rendering', () => {
+  it('renders hero section and canvas without crashing', () => {
+    render(<Page />);
+    expect(screen.getByText('안녕하세요, 원도훈입니다.')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- test toggling of mobile menu in Header
- ensure main page hero and canvas render without crashing

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_683fa9e3d66c8323bc0df3efc30ec114