### PR TITLE
Improve hero section and custom cursor

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -234,13 +234,13 @@ export default function Page() {
 
           <div className="relative z-10 text-center p-4 max-w-3xl">
             <motion.h1
-              className="text-5xl font-extrabold mb-6 text-white"
+              className="text-5xl sm:text-6xl font-extrabold mb-6 bg-gradient-to-r from-indigo-400 via-purple-400 to-pink-400 bg-clip-text text-transparent"
               style={{ letterSpacing: '0.1em' }}
               initial={{ opacity: 0, y: 50 }}
               animate={heroInView ? { opacity: 1, y: 0 } : {}}
               transition={{ duration: 1, delay: 0.2 }}
             >
-              안녕하세요, 원도훈입니다.
+              프론트엔드 개발자 원도훈입니다.
             </motion.h1>
             <motion.p
               className="text-2xl mb-10 text-white/90"

--- a/src/components/CustomCursor.tsx
+++ b/src/components/CustomCursor.tsx
@@ -80,7 +80,13 @@ export default function CustomCursor() {
         }}
         transition={{ type: 'spring', stiffness: 300, damping: 20 }}
       >
-        <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg
+          width="40"
+          height="40"
+          viewBox="0 0 40 40"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
           <motion.circle
             cx="20"
             cy="20"
@@ -92,22 +98,34 @@ export default function CustomCursor() {
             transition={{ duration: 0.3 }}
           />
           <motion.path
-            d="M20 12L20 28M12 20L28 20"
+            d="M15 14 L12 20 L15 26"
             stroke={cursorColor}
             strokeWidth="2"
             strokeLinecap="round"
+            fill="none"
             initial={{ pathLength: 0 }}
             animate={{ pathLength: 1 }}
-            transition={{ duration: 0.5, delay: 0.2 }}
+            transition={{ duration: 0.3 }}
           />
           <motion.path
-            d="M14 14L26 26M14 26L26 14"
+            d="M25 14 L28 20 L25 26"
             stroke={cursorColor}
             strokeWidth="2"
             strokeLinecap="round"
+            fill="none"
+            initial={{ pathLength: 0 }}
+            animate={{ pathLength: 1 }}
+            transition={{ duration: 0.3, delay: 0.1 }}
+          />
+          <motion.path
+            d="M18 14 L22 26"
+            stroke={cursorColor}
+            strokeWidth="2"
+            strokeLinecap="round"
+            fill="none"
             initial={{ pathLength: 0 }}
             animate={{ pathLength: isHovered ? 1 : 0 }}
-            transition={{ duration: 0.3 }}
+            transition={{ duration: 0.3, delay: 0.2 }}
           />
         </svg>
       </motion.div>


### PR DESCRIPTION
## Summary
- upgrade hero heading to colorful gradient style
- redesign custom cursor with code bracket icon

## Testing
- `npm test --silent` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_683fb4c0889c8323b331c789ecff592d