### PR TITLE
Implement interactive one page portfolio

### DIFF
--- a/__tests__/Page.test.tsx
+++ b/__tests__/Page.test.tsx
@@ -29,7 +29,7 @@ beforeAll(() => {
 describe('Main page rendering', () => {
   it('renders hero section and canvas without crashing', () => {
     render(<Page />);
-    expect(screen.getByText('안녕하세요, 원도훈입니다.')).toBeInTheDocument();
+    expect(screen.getByText('Frontend Developer 원도훈')).toBeInTheDocument();
     expect(screen.getByTestId('canvas')).toBeInTheDocument();
   });
 });

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  siteUrl: 'https://example.com',
+  generateRobotsTxt: true,
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -76,7 +76,6 @@
 }
 
 body {
-    cursor: none;
     color: rgb(var(--foreground-rgb));
     background: linear-gradient(
             to bottom,
@@ -86,6 +85,14 @@ body {
     rgb(var(--background-start-rgb));
 }
 
-a, button {
-    cursor: none;
+body::after {
+    content: "";
+    pointer-events: none;
+    position: fixed;
+    inset: 0;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' fill='%23fff'/%3E%3C/svg%3E");
+    opacity: 0.05;
+    mix-blend-mode: overlay;
+    z-index: 50;
 }
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,11 @@
+"use client";
 import './globals.css'
 import { ReactNode } from 'react'
 import { Noto_Sans_KR } from 'next/font/google'
 import Header from '@/components/Header'
 import DarkModeToggle from "@/components/DarkModeToggle";
+import ScrollProgress from '@/components/ScrollProgress'
+import useLenis from '@/lib/useLenis'
 
 const notoSansKr = Noto_Sans_KR({
   subsets: ['latin'],
@@ -10,11 +13,25 @@ const notoSansKr = Noto_Sans_KR({
 })
 
 export const metadata = {
-  title: 'My Portfolio',
-  description: 'A showcase of my work and skills',
+  title: 'Frontend Developer 원도훈',
+  description: '원도훈의 포트폴리오',
+  openGraph: {
+    title: 'Frontend Developer 원도훈',
+    description: '원도훈의 포트폴리오',
+    url: 'https://example.com',
+    siteName: '원도훈 포트폴리오',
+    locale: 'ko_KR',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Frontend Developer 원도훈',
+    description: '원도훈의 포트폴리오',
+  },
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  useLenis()
   const themeScript = `
     (function() {
       const savedTheme = localStorage.getItem('theme');
@@ -31,8 +48,20 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="ko" className={notoSansKr.className} suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'Person',
+              name: '원도훈',
+              url: 'https://example.com',
+            }),
+          }}
+        />
       </head>
       <body className="bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100 transition-colors duration-300 relative overflow-x-hidden">
+        <ScrollProgress />
         <Header/>
         <main className="pt-16 min-h-screen">
           {children}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <h2 className="text-2xl">페이지를 찾을 수 없습니다.</h2>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,9 @@ import { ParallaxProvider, Parallax } from 'react-scroll-parallax'
 import * as THREE from 'three'
 import ContactForm from '@/components/ContactForm'
 import { Github, Linkedin, ExternalLink } from 'lucide-react'
+import dynamic from 'next/dynamic'
+const HeroParticles = dynamic(() => import('@/components/HeroParticles'), { ssr: false })
+import { projects, Project } from '@/data/projects'
 
 // Velog 아이콘 (간단히 'V'로 표시)
 function VelogIcon(props: React.SVGProps<SVGSVGElement>) {
@@ -18,132 +21,9 @@ function VelogIcon(props: React.SVGProps<SVGSVGElement>) {
   );
 }
 
-// 회전하는 박스 컴포넌트
-function RotatingBox() {
-  const ref = useRef<THREE.Mesh>(null)
-  const [hue, setHue] = useState(0)
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setHue((prevHue) => (prevHue + 1) % 360)
-    }, 50)
-    return () => clearInterval(interval)
-  }, [])
 
-  useFrame(() => {
-    if (ref.current) {
-      ref.current.rotation.x += 0.003
-      ref.current.rotation.y += 0.003
-    }
-  })
-
-  const color = `hsl(${hue}, 100%, 50%)`
-  return (
-    <mesh ref={ref} position={[0, 0, 0]} scale={1.3}>
-      <boxGeometry args={[1, 1, 1]} />
-      <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.3} />
-    </mesh>
-  )
-}
-
-// 프로젝트 인터페이스
-interface Project {
-  name: string;
-  github?: string;
-  live?: string;
-  description?: string;
-  techStack: string[];
-}
-
-// 프로젝트 목록
-const projects: Project[] = [
-  {
-    name: "하루 끝",
-    github: "https://github.com/oz-EndOfDay/FE",
-    live: "https://www.endofday.store/",
-    description: "NEXT.JS 기반으로 제작한 일기장 프로젝트, Vercel 배포.",
-    techStack: ["NEXT.JS", "React", "TailwindCSS", "Vercel", "TypeScript", "Redux Toolkit", "React Query"]
-  },
-  {
-    name: "Movie DH",
-    github: "https://github.com/wdohoon/Movie",
-    live: "https://glittering-torrone-89e130.netlify.app/",
-    description: "React 기반으로 영화 API를 연동한 영화 정보 사이트, Netlify 배포.",
-    techStack: ["React", "ContextAPI", "TailwindCSS", "Supabase", "JavaScript"]
-  },
-  {
-    name: "다움성형외과",
-    live: "https://www.dawoomps.com/",
-    description: "회사 재직 중 제작한 상업용 사이트.",
-    techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP"]
-  },
-  {
-    name: "이루다몰(클래시스몰)",
-    live: "https://classysshop.com/",
-    description: "회사 재직 중 제작한 상업용 사이트.",
-    techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma", "AJAX", "AWS"]
-  },
-  {
-    name: "TeamHope",
-    live: "http://www.teamhope.co.kr/",
-    description: "회사에서 제작한 기업용 사이트.",
-    techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"]
-  },
-  {
-    name: "Bhidex",
-    live: "https://bhidex.gabia.io/",
-    description: "전문 사이트 개발 경험.",
-    techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"]
-  },
-  {
-    name: "사주보궁",
-    live: "http://saju79.net/",
-    description: "사주/운세 서비스 사이트.",
-    techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"]
-  },
-  {
-    name: "마더스 제약",
-    live: "http://www.mtspharm.co.kr/",
-    description: "제약 관련 사이트 구축.",
-    techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"]
-  },
-  {
-    name: "한식세끼",
-    live: "https://xn--h10b903achbe83b.com/",
-    description: "한국 음식 관련 상업 사이트.",
-    techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"]
-  },
-  {
-    name: "Moden7ai",
-    live: "http://moden7ai.com",
-    description: "회사 홍보 서비스 프로젝트.",
-    techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"]
-  },
-  {
-    name: "Kidb",
-    live: "https://www.kidb.com/",
-    description: "기업 정보 관련 프로젝트.",
-    techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"]
-  },
-  {
-    name: "종로학원",
-    live: "https://www.jongro.co.kr/",
-    description: "유지보수 및 기능 개선.",
-    techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"]
-  },
-  {
-    name: "셀트리온",
-    live: "https://www.celltrion.com",
-    description: "바이오테크 기업 웹사이트 유지보수.",
-    techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"]
-  },
-  {
-    name: "Kacelab 포트폴리오",
-    live: "https://www.kacelab.com/Work.php",
-    description: "Kacelab 포트폴리오 섹션 작업.",
-    techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"]
-  },
-];
+// 프로젝트 인터페이스는 src/data/projects.ts에서 가져옵니다.
 
 // 스킬 인터페이스
 interface Skill {
@@ -221,12 +101,7 @@ export default function Page() {
           id="hero"
           className="w-full h-screen relative flex flex-col items-center justify-center bg-gradient-to-br from-[#0f0c29] via-[#302b63] to-[#24243e]"
         >
-          <Canvas className="absolute inset-0 !h-1/2">
-            <ambientLight intensity={0.5} />
-            <directionalLight position={[2, 5, 5]} />
-            <RotatingBox />
-            <OrbitControls enablePan={false} enableZoom={false} enableRotate={false} />
-          </Canvas>
+          <HeroParticles />
 
           <Parallax speed={-10} className="absolute inset-0">
             <div className="w-full h-full bg-[url('/path/to/your/bg-pattern.png')] opacity-20" />
@@ -240,7 +115,7 @@ export default function Page() {
               animate={heroInView ? { opacity: 1, y: 0 } : {}}
               transition={{ duration: 1, delay: 0.2 }}
             >
-              프론트엔드 개발자 원도훈입니다.
+              Frontend Developer 원도훈
             </motion.h1>
             <motion.p
               className="text-2xl mb-10 text-white/90"
@@ -259,6 +134,15 @@ export default function Page() {
             >
               프로젝트 보러가기
             </motion.a>
+            <motion.div
+              className="mt-12 flex justify-center"
+              animate={{ y: [0, 10, 0] }}
+              transition={{ repeat: Infinity, duration: 1.5 }}
+            >
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-white">
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </motion.div>
           </div>
         </section>
 
@@ -402,7 +286,7 @@ export default function Page() {
             {projects.map((project: Project, i: number) => (
               <motion.div
                 key={i}
-                className="p-6 bg-white dark:bg-gray-800 shadow-lg rounded-lg flex flex-col items-start justify-between transform hover:scale-105 transition duration-300"
+                className="p-6 bg-white/80 dark:bg-surface/80 backdrop-blur-xl shadow-lg rounded-lg flex flex-col items-start justify-between transform hover:scale-105 transition duration-300"
                 variants={{
                   hidden: { opacity: 0, y: 50 },
                   visible: { opacity: 1, y: 0, transition: { type: 'spring', stiffness: 50 } },

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import { useState } from 'react';
-import CustomCursor from "@/components/CustomCursor";
 
 export default function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   return (
     <header className="fixed w-full bg-white/80 dark:bg-gray-800/80 backdrop-blur-md z-50 shadow-md">
-      <CustomCursor />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           <a href="/" className="text-2xl font-bold bg-gradient-to-r from-blue-500 to-teal-400 bg-clip-text text-transparent">

--- a/src/components/HeroParticles.tsx
+++ b/src/components/HeroParticles.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { Canvas, useFrame } from '@react-three/fiber';
+import { useRef, useMemo } from 'react';
+import * as THREE from 'three';
+
+function Particles() {
+  const ref = useRef<THREE.Points>(null);
+  const positions = useMemo(() => {
+    const arr = new Float32Array(2000 * 3);
+    for (let i = 0; i < arr.length; i++) {
+      arr[i] = (Math.random() - 0.5) * 5;
+    }
+    return arr;
+  }, []);
+
+  useFrame((state) => {
+    if (ref.current) ref.current.rotation.y += 0.001;
+  });
+
+  return (
+    <points ref={ref}>
+      <bufferGeometry>
+        <bufferAttribute
+          attach="attributes-position"
+          array={positions}
+          count={positions.length / 3}
+          itemSize={3}
+        />
+      </bufferGeometry>
+      <pointsMaterial color="#ffffff" size={0.02} />
+    </points>
+  );
+}
+
+export default function HeroParticles() {
+  return (
+    <Canvas className="absolute inset-0">
+      <ambientLight intensity={0.5} />
+      <Particles />
+    </Canvas>
+  );
+}

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -1,0 +1,12 @@
+"use client";
+import { motion, useScroll } from 'framer-motion';
+
+export default function ScrollProgress() {
+  const { scrollYProgress } = useScroll();
+  return (
+    <motion.div
+      className="fixed top-0 left-0 right-0 h-1 bg-accent origin-left z-50"
+      style={{ scaleX: scrollYProgress }}
+    />
+  );
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,24 @@
+export interface Project {
+  name: string;
+  github?: string;
+  live?: string;
+  description?: string;
+  techStack: string[];
+}
+
+export const projects: Project[] = [
+  { name: "하루 끝", github: "https://github.com/oz-EndOfDay/FE", live: "https://www.endofday.store/", description: "NEXT.JS 기반으로 제작한 일기장 프로젝트, Vercel 배포.", techStack: ["NEXT.JS", "React", "TailwindCSS", "Vercel", "TypeScript", "Redux Toolkit", "React Query"] },
+  { name: "Movie DH", github: "https://github.com/wdohoon/Movie", live: "https://glittering-torrone-89e130.netlify.app/", description: "React 기반으로 영화 API를 연동한 영화 정보 사이트, Netlify 배포.", techStack: ["React", "ContextAPI", "TailwindCSS", "Supabase", "JavaScript"] },
+  { name: "다움성형외과", live: "https://www.dawoomps.com/", description: "회사 재직 중 제작한 상업용 사이트.", techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP"] },
+  { name: "이루다몰(클래시스몰)", live: "https://classysshop.com/", description: "회사 재직 중 제작한 상업용 사이트.", techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma", "AJAX", "AWS"] },
+  { name: "TeamHope", live: "http://www.teamhope.co.kr/", description: "회사에서 제작한 기업용 사이트.", techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"] },
+  { name: "Bhidex", live: "https://bhidex.gabia.io/", description: "전문 사이트 개발 경험.", techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"] },
+  { name: "사주보궁", live: "http://saju79.net/", description: "사주/운세 서비스 사이트.", techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"] },
+  { name: "마더스 제약", live: "http://www.mtspharm.co.kr/", description: "제약 관련 사이트 구축.", techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"] },
+  { name: "한식세끼", live: "https://xn--h10b903achbe83b.com/", description: "한국 음식 관련 상업 사이트.", techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"] },
+  { name: "Moden7ai", live: "http://moden7ai.com", description: "회사 홍보 서비스 프로젝트.", techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"] },
+  { name: "Kidb", live: "https://www.kidb.com/", description: "기업 정보 관련 프로젝트.", techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"] },
+  { name: "종로학원", live: "https://www.jongro.co.kr/", description: "유지보수 및 기능 개선.", techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"] },
+  { name: "셀트리온", live: "https://www.celltrion.com", description: "바이오테크 기업 웹사이트 유지보수.", techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"] },
+  { name: "Kacelab 포트폴리오", live: "https://www.kacelab.com/Work.php", description: "Kacelab 포트폴리오 섹션 작업.", techStack: ["HTML", "CSS", "JavaScript", "jQuery", "MySQL", "PHP", "Figma"] },
+];

--- a/src/lib/useLenis.ts
+++ b/src/lib/useLenis.ts
@@ -1,0 +1,27 @@
+"use client";
+import { useEffect } from 'react';
+
+export default function useLenis() {
+  useEffect(() => {
+    let lenis: any;
+    let id: number;
+    (async () => {
+      try {
+        const mod = await import('@studio-freight/lenis');
+        const Lenis = (mod as any).default || (mod as any).Lenis;
+        lenis = new Lenis({ lerp: 0.1, smooth: true });
+        const raf = (time: number) => {
+          lenis.raf(time);
+          id = requestAnimationFrame(raf);
+        };
+        requestAnimationFrame(raf);
+      } catch (e) {
+        console.warn('Lenis not loaded', e);
+      }
+    })();
+    return () => {
+      if (lenis) lenis.destroy();
+      cancelAnimationFrame(id);
+    };
+  }, []);
+}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,7 @@
+export default function NotFoundPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <h1 className="text-3xl">페이지를 찾을 수 없습니다.</h1>
+    </div>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../app/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html lang="ko">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,11 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        primary: '#7E3FF2',
+        accent: '#FFB703',
+        surface: '#101010',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- add lenis hook and scroll progress bar
- style hero section with dynamic particles
- central headline updated
- glassmorphism project cards and progress bar
- add dark mode, metadata and schema
- move project data to dedicated file
- add basic app router pages

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_683fc5c7ba948323898b3df09f82b454